### PR TITLE
Exclude comparison of a message with itself from weight calculations

### DIFF
--- a/coordination_network_toolkit/compute_networks.py
+++ b/coordination_network_toolkit/compute_networks.py
@@ -256,6 +256,7 @@ def compute_co_tweet_network(
             and e_2.timestamp between e_1.timestamp - ?1 and e_1.timestamp + ?1
             and e_1.repost_id is null
             and e_2.repost_id is null
+            and e_1.message_id != e_2.message_id
         where user_1 in (select user_id from user_id)
         group by e_1.user_id, e_2.user_id
         having weight >= ?2
@@ -325,6 +326,7 @@ def compute_co_reply_network(db_path, time_window, min_edge_weight=1, n_threads=
             and e_2.timestamp between e_1.timestamp - ?1 and e_1.timestamp + ?1
             and e_1.repost_id is null
             and e_2.repost_id is null
+            and e_1.message_id != e_2.message_id
         where user_1 in (select user_id from user_id)
         group by e_1.user_id, e_2.user_id
         having weight >= ?2
@@ -392,6 +394,7 @@ def compute_co_post_network(db_path, time_window, min_edge_weight=1, n_threads=4
         from edge e_1
         inner join edge e_2
             on e_2.timestamp between e_1.timestamp - ?1 and e_1.timestamp + ?1
+            and e_1.message_id != e_2.message_id
         where user_1 in (select user_id from user_id)
         group by e_1.user_id, e_2.user_id
         having weight >= ?2
@@ -475,6 +478,7 @@ def compute_co_link_network(
                 -- Keep any row where the retweets are by different users and within n
                 -- seconds of each other.
                 and e_2.timestamp between e_1.timestamp - ?1 and e_1.timestamp + ?1
+                and e_1.message_id != e_2.message_id
             where user_1 in (select user_id from user_id)
             group by e_1.user_id, e_2.user_id
             having weight >= ?2
@@ -515,6 +519,7 @@ def compute_co_link_network(
             inner join message_url e_2
                 on e_1.url = e_2.url
                 and e_2.timestamp between e_1.timestamp - ?1 and e_1.timestamp + ?1
+                and e_1.message_id != e_2.message_id
             where user_1 in (select user_id from user_id)
             group by e_1.user_id, e_2.user_id
             having weight >= ?2
@@ -623,6 +628,7 @@ def compute_co_similar_tweet(
             and e_2.token_set is not null
             and similarity(e_1.token_set, e_2.token_set) >= ?3
             and user_1 in (select user_id from user_id)
+            and e_1.message_id != e_2.message_id
         group by e_1.user_id, e_2.user_id
         having weight >= ?2
     """
@@ -683,6 +689,7 @@ def compute_co_retweet_parallel(db_path, time_window, n_threads=4, min_edge_weig
             and e_2.timestamp between e_1.timestamp - ?1
                 and e_1.timestamp + ?1
             and user_1 in (select user_id from user_id)
+            and e_1.message_id != e_2.message_id
         group by e_1.user_id, e_2.user_id
         having weight >= ?
     """

--- a/tests/data/coretweet_test_input.csv
+++ b/tests/data/coretweet_test_input.csv
@@ -13,3 +13,4 @@
 11,uid10,username10,rtid5,,"Example tweet from uid10",52,""
 12,uid11,username11,rtid6,,"Example tweet from uid11",42,""
 13,uid12,username12,rtid6,,"Example tweet from uid12",300,""
+14,uid0,username0,rtid0,,"Example tweet from uid0",1,""

--- a/tests/test_graph_construction.py
+++ b/tests/test_graph_construction.py
@@ -17,13 +17,16 @@ def test_graph_construction_workflow(tmpdir):
     settings_nodes = (
         # (Time window, min_edge_weight, loops in the output), expected nodes
         ((1, 1, False), 2),
-        ((1, 1, True), 9),  # Self loops will always include a single retweet
+        # 2 accounts retweeting each other + 1 account retweeting itself
+        ((1, 1, True), 3),
         ((1, 2, False), 0),  # No edges over the cutoff weight
-        ((1, 2, True), 5),  # 5 accounts with more than one retweet for the self loop
+        ((1, 2, True), 1),  # Only 1 account above the threshold with the self loop
         # Note that in this example, uid10 retweets a message twice - this is
         # counted as a self loop so not included in the output nodes.
         ((60, 1, False), 6),
-        ((60, 1, True), 9),  # All of the nodes should be included with self loops
+        # All of the nodes except for 11 and 12 should be included - node 11
+        # and 12 are too far apart in time to be included
+        ((60, 1, True), 7),
     )
 
     for n_threads in (1, 2, 4):


### PR DESCRIPTION
Changes the weight quantification to exclude comparisons of a message with itself. Previous to this change every activity by a user that met the criteria for that network type would be included in the self edge weight - eg. every retweet would be a co-retweet with itself.

The previous behaviour is undesirable because it significantly inflates the weight of self edges according to the account activity - this change gives a more accurate representation of the self edge weight, allowing easier detection of things like reply spam from a single account. I think the earlier behaviour is more of an oversight because we focused more on coordination across accounts rather than the self similarity.